### PR TITLE
Fix for package level reference numbers

### DIFF
--- a/modules/connectors/ups/karrio/providers/ups/shipment/create.py
+++ b/modules/connectors/ups/karrio/providers/ups/shipment/create.py
@@ -761,7 +761,7 @@ def shipment_request(
                             ups.ReferenceNumberType(
                                 Value=package.parcel.reference_number,
                             )
-                            if (country_pair not in ["US/US", "PR/PR"])
+                            if (country_pair in ["US/US", "PR/PR"])
                             and any(package.parcel.reference_number or "")
                             else None
                         ),


### PR DESCRIPTION
Package level reference numbers are valid for US/PR shipments (opposite of SHIPMENT level reference numbers), per UPS docs.